### PR TITLE
Add deletion and improved date selection

### DIFF
--- a/mobile/app/(tabs)/analytics.tsx
+++ b/mobile/app/(tabs)/analytics.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, Dimensions, Pressable } from 'react-native';
+import { StyleSheet, Dimensions, Pressable, Modal, View } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { PieChart } from 'react-native-chart-kit';
 import { ThemedText } from '@/components/ThemedText';
@@ -8,7 +8,7 @@ import { useBudget } from '@/contexts/BudgetContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/Colors';
 export default function AnalyticsScreen() {
-  const { transactions } = useBudget();
+  const { transactions, categories } = useBudget();
   const scheme = useColorScheme() ?? 'light';
   const [startDate, setStartDate] = useState(new Date(new Date().getFullYear(), new Date().getMonth(), 1));
   const [endDate, setEndDate] = useState(new Date());
@@ -19,29 +19,26 @@ export default function AnalyticsScreen() {
     const d = new Date(t.date);
     return d >= startDate && d <= endDate;
   });
-  const income = filtered
-    .filter((t) => t.type === 'income')
-    .reduce((sum, t) => sum + t.amount, 0);
-  const expense = filtered
-    .filter((t) => t.type === 'expense')
-    .reduce((sum, t) => sum + t.amount, 0);
 
-  const data = [
-    {
-      name: 'Income',
-      population: income,
-      color: '#4CAF50',
-      legendFontColor: Colors[scheme].text,
-      legendFontSize: 15,
-    },
-    {
-      name: 'Expense',
-      population: expense,
-      color: '#F44336',
-      legendFontColor: Colors[scheme].text,
-      legendFontSize: 15,
-    },
-  ];
+  const expenseTotals = categories
+    .filter((c) => c.type === 'expense')
+    .map((c) => {
+      const total = filtered
+        .filter((t) => t.type === 'expense' && t.categoryId === c.id)
+        .reduce((sum, t) => sum + t.amount, 0);
+      return { name: c.name, total };
+    })
+    .filter((d) => d.total > 0);
+
+  const COLORS = ['#F44336', '#E91E63', '#9C27B0', '#2196F3', '#009688', '#FF9800', '#795548'];
+
+  const data = expenseTotals.map((d, idx) => ({
+    name: d.name,
+    population: d.total,
+    color: COLORS[idx % COLORS.length],
+    legendFontColor: Colors[scheme].text,
+    legendFontSize: 15,
+  }));
 
   return (
     <ThemedView style={styles.container}>
@@ -49,31 +46,39 @@ export default function AnalyticsScreen() {
       <Pressable onPress={() => setShowStart(true)} style={styles.dateButton}>
         <ThemedText>From: {startDate.toLocaleDateString()}</ThemedText>
       </Pressable>
-      {showStart && (
-        <DateTimePicker
-          value={startDate}
-          mode="date"
-          display="default"
-          onChange={(e, d) => {
-            setShowStart(false);
-            if (d) setStartDate(d);
-          }}
-        />
-      )}
+      <Modal transparent visible={showStart} animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <DateTimePicker
+              value={startDate}
+              mode="date"
+              display="calendar"
+              onChange={(e, d) => {
+                setShowStart(false);
+                if (d) setStartDate(d);
+              }}
+            />
+          </View>
+        </View>
+      </Modal>
       <Pressable onPress={() => setShowEnd(true)} style={styles.dateButton}>
         <ThemedText>To: {endDate.toLocaleDateString()}</ThemedText>
       </Pressable>
-      {showEnd && (
-        <DateTimePicker
-          value={endDate}
-          mode="date"
-          display="default"
-          onChange={(e, d) => {
-            setShowEnd(false);
-            if (d) setEndDate(d);
-          }}
-        />
-      )}
+      <Modal transparent visible={showEnd} animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <DateTimePicker
+              value={endDate}
+              mode="date"
+              display="calendar"
+              onChange={(e, d) => {
+                setShowEnd(false);
+                if (d) setEndDate(d);
+              }}
+            />
+          </View>
+        </View>
+      </Modal>
       <PieChart
         data={data}
         width={Dimensions.get('window').width - 32}
@@ -107,5 +112,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 8,
   },
 });

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, Button, Pressable } from 'react-native';
+import { StyleSheet, Button, Pressable, Modal, View } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
@@ -10,7 +10,8 @@ import { ThemedTextInput } from '@/components/ThemedTextInput';
 import { useBudget } from '@/contexts/BudgetContext';
 
 export default function HomeScreen() {
-  const { categories, transactions, addTransaction, addCategory } = useBudget();
+  const { categories, transactions, addTransaction, addCategory, deleteTransaction } =
+    useBudget();
   const [amount, setAmount] = useState('');
   const [type, setType] = useState<'income' | 'expense'>('expense');
   const [categoryId, setCategoryId] = useState('');
@@ -73,17 +74,21 @@ export default function HomeScreen() {
       <Pressable onPress={() => setShowDatePicker(true)} style={styles.dateButton}>
         <ThemedText>{date.toLocaleDateString()}</ThemedText>
       </Pressable>
-      {showDatePicker && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="default"
-          onChange={(e, d) => {
-            setShowDatePicker(false);
-            if (d) setDate(d);
-          }}
-        />
-      )}
+      <Modal transparent visible={showDatePicker} animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <DateTimePicker
+              value={date}
+              mode="date"
+              display="calendar"
+              onChange={(e, d) => {
+                setShowDatePicker(false);
+                if (d) setDate(d);
+              }}
+            />
+          </View>
+        </View>
+      </Modal>
       <Button title="Add" onPress={submitTransaction} />
       <ThemedText type="subtitle" style={styles.section}>Add Category</ThemedText>
       <Picker selectedValue={newCategoryType} onValueChange={(v) => setNewCategoryType(v)} style={styles.picker}>
@@ -99,9 +104,16 @@ export default function HomeScreen() {
       <Button title="Add Category" onPress={submitCategory} />
       <ThemedText type="subtitle" style={styles.section}>Transactions</ThemedText>
       {transactions.map((t) => (
-        <ThemedText key={t.id}>
-          {t.type === 'expense' ? '-' : '+'}{t.amount} ({categories.find(c => c.id === t.categoryId)?.name}) - {new Date(t.date).toLocaleDateString()}
-        </ThemedText>
+        <ThemedView key={t.id} style={styles.transactionRow}>
+          <ThemedText>
+            {t.type === 'expense' ? '-' : '+'}
+            {t.amount} ({categories.find((c) => c.id === t.categoryId)?.name}) -{' '}
+            {new Date(t.date).toLocaleDateString()}
+          </ThemedText>
+          <Pressable onPress={() => deleteTransaction(t.id)}>
+            <ThemedText style={styles.deleteText}>Delete</ThemedText>
+          </Pressable>
+        </ThemedView>
       ))}
     </ThemedView>
   );
@@ -131,6 +143,26 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
     borderRadius: 4,
     alignItems: 'center',
+  },
+  transactionRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  deleteText: {
+    color: 'red',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 8,
   },
 });
 

--- a/mobile/contexts/BudgetContext.tsx
+++ b/mobile/contexts/BudgetContext.tsx
@@ -30,6 +30,7 @@ interface BudgetContextValue extends BudgetState {
     description?: string,
     date?: Date,
   ) => void;
+  deleteTransaction: (id: string) => void;
 }
 
 const BudgetContext = createContext<BudgetContextValue | undefined>(undefined);
@@ -108,8 +109,14 @@ export function BudgetProvider({ children }: { children: React.ReactNode }) {
     ]);
   };
 
+  const deleteTransaction = (id: string) => {
+    setTransactions((prev) => prev.filter((t) => t.id !== id));
+  };
+
   return (
-    <BudgetContext.Provider value={{ categories, transactions, addCategory, addTransaction }}>
+    <BudgetContext.Provider
+      value={{ categories, transactions, addCategory, addTransaction, deleteTransaction }}
+    >
       {children}
     </BudgetContext.Provider>
   );


### PR DESCRIPTION
## Summary
- support deleting transactions
- improve date selection with calendar modals
- allow analytics period selection
- show analytics chart by expense categories

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617da97fe083278597c568d63411d9