### PR TITLE
Add theme switcher and fix date picker modals

### DIFF
--- a/mobile/app/(tabs)/analytics.tsx
+++ b/mobile/app/(tabs)/analytics.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, Dimensions, Pressable, Modal, View, Button } from 'react-native';
+import { StyleSheet, Dimensions, Pressable, Modal, View, Button, Platform } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { PieChart } from 'react-native-chart-kit';
 import { ThemedText } from '@/components/ThemedText';
@@ -7,6 +7,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { useBudget } from '@/contexts/BudgetContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Colors } from '@/constants/Colors';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
 export default function AnalyticsScreen() {
   const { transactions, categories } = useBudget();
   const scheme = useColorScheme() ?? 'light';
@@ -31,35 +32,38 @@ export default function AnalyticsScreen() {
     })
     .filter((d) => d.total > 0);
 
-  const COLORS = ['#F44336', '#E91E63', '#9C27B0', '#2196F3', '#009688', '#FF9800', '#795548'];
+  const EXPENSE_COLORS = ['#FFCDD2', '#EF9A9A', '#E57373', '#EF5350', '#F44336'];
+  const INCOME_COLORS = ['#C8E6C9', '#A5D6A7', '#81C784', '#66BB6A', '#4CAF50'];
+  const palette = viewType === 'expense' ? EXPENSE_COLORS : INCOME_COLORS;
 
   const data = totals.map((d, idx) => ({
     name: d.name,
     population: d.total,
-    color: COLORS[idx % COLORS.length],
+    color: palette[idx % palette.length],
     legendFontColor: Colors[scheme].text,
     legendFontSize: 15,
   }));
 
   return (
     <ThemedView style={styles.container}>
+      <ThemeToggleButton />
       <ThemedText type="title">Analytics</ThemedText>
       <Pressable onPress={() => setShowStart(true)} style={styles.dateButton}>
         <ThemedText>From: {startDate.toLocaleDateString()}</ThemedText>
       </Pressable>
       <Modal transparent visible={showStart} animationType="slide">
         <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
+          <ThemedView style={styles.modalContent}>
             <DateTimePicker
               value={startDate}
               mode="date"
-              display="calendar"
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
               onChange={(e, d) => {
                 setShowStart(false);
                 if (d) setStartDate(d);
               }}
             />
-          </View>
+          </ThemedView>
         </View>
       </Modal>
       <Pressable onPress={() => setShowEnd(true)} style={styles.dateButton}>
@@ -67,17 +71,17 @@ export default function AnalyticsScreen() {
       </Pressable>
       <Modal transparent visible={showEnd} animationType="slide">
         <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
+          <ThemedView style={styles.modalContent}>
             <DateTimePicker
               value={endDate}
               mode="date"
-              display="calendar"
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
               onChange={(e, d) => {
                 setShowEnd(false);
                 if (d) setEndDate(d);
               }}
             />
-          </View>
+          </ThemedView>
         </View>
       </Modal>
       <View style={styles.switchRow}>
@@ -131,7 +135,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   modalContent: {
-    backgroundColor: '#fff',
     padding: 16,
     borderRadius: 8,
   },

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, Button, Pressable, Modal, View, ScrollView } from 'react-native';
+import { StyleSheet, Button, Pressable, Modal, View, ScrollView, Platform } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedTextInput } from '@/components/ThemedTextInput';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
 
 import { useBudget } from '@/contexts/BudgetContext';
 
@@ -53,6 +54,7 @@ export default function HomeScreen() {
 
   return (
     <ThemedView style={styles.container}>
+      <ThemeToggleButton />
       <ThemedText type="title">Budget</ThemedText>
       <View style={styles.addButtons}>
         <Button
@@ -73,7 +75,7 @@ export default function HomeScreen() {
 
       <Modal transparent visible={showTransactionModal} animationType="slide">
         <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
+          <ThemedView style={styles.modalContent}>
             <ScrollView>
               <ThemedText type="subtitle">Add Transaction</ThemedText>
               <Picker selectedValue={type} onValueChange={(v) => setType(v)} style={styles.picker}>
@@ -108,17 +110,17 @@ export default function HomeScreen() {
               </Pressable>
               <Modal transparent visible={showDatePicker} animationType="slide">
                 <View style={styles.modalOverlay}>
-                  <View style={styles.modalContent}>
+                  <ThemedView style={styles.modalContent}>
                     <DateTimePicker
                       value={date}
                       mode="date"
-                      display="calendar"
+                      display={Platform.OS === 'ios' ? 'spinner' : 'default'}
                       onChange={(e, d) => {
                         setShowDatePicker(false);
                         if (d) setDate(d);
                       }}
                     />
-                  </View>
+                  </ThemedView>
                 </View>
               </Modal>
               <Button title="Save" onPress={() => { submitTransaction(); setShowTransactionModal(false); }} />
@@ -130,7 +132,7 @@ export default function HomeScreen() {
 
       <Modal transparent visible={showCategoryModal} animationType="slide">
         <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
+          <ThemedView style={styles.modalContent}>
             <ThemedText type="subtitle">Manage Categories</ThemedText>
             {categories
               .filter((c) => c.type === type)
@@ -158,7 +160,7 @@ export default function HomeScreen() {
             />
             <Button title="Add Category" onPress={submitCategory} />
             <Button title="Close" onPress={() => setShowCategoryModal(false)} />
-          </View>
+          </ThemedView>
         </View>
       </Modal>
 
@@ -241,7 +243,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   modalContent: {
-    backgroundColor: '#fff',
     padding: 16,
     borderRadius: 8,
   },

--- a/mobile/app/(tabs)/planner.tsx
+++ b/mobile/app/(tabs)/planner.tsx
@@ -1,10 +1,12 @@
 import { StyleSheet } from 'react-native';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function PlannerScreen() {
   return (
     <ThemedView style={styles.container}>
+      <ThemeToggleButton />
       <ThemedText type="title">Plan</ThemedText>
       <ThemedText>Create budgets for day, month or custom periods.</ThemedText>
     </ThemedView>

--- a/mobile/app/(tabs)/scanner.tsx
+++ b/mobile/app/(tabs)/scanner.tsx
@@ -1,10 +1,12 @@
 import { StyleSheet } from 'react-native';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function ScannerScreen() {
   return (
     <ThemedView style={styles.container}>
+      <ThemeToggleButton />
       <ThemedText type="title">Receipt Scanner</ThemedText>
       <ThemedText>Use your camera to scan receipts and auto-add expenses.</ThemedText>
     </ThemedView>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,23 +1,34 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { BudgetProvider } from '@/contexts/BudgetContext';
+import { ThemeProvider } from '@/contexts/ThemeContext';
 
 export default function RootLayout() {
+  return (
+    <ThemeProvider>
+      <RootLayoutInner />
+    </ThemeProvider>
+  );
+}
+
+function RootLayoutInner() {
   const colorScheme = useColorScheme();
 
   return (
     <BudgetProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <NavigationThemeProvider
+        value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+      >
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="+not-found" />
         </Stack>
         <StatusBar style="auto" />
-      </ThemeProvider>
+      </NavigationThemeProvider>
     </BudgetProvider>
   );
 }

--- a/mobile/components/ThemeToggleButton.tsx
+++ b/mobile/components/ThemeToggleButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { ThemedText } from './ThemedText';
+import { useTheme } from '@/contexts/ThemeContext';
+
+export default function ThemeToggleButton() {
+  const { theme, toggle } = useTheme();
+  return (
+    <Pressable onPress={toggle} style={styles.button} accessibilityLabel="toggle theme">
+      <ThemedText>{theme === 'light' ? '🌙' : '☀️'}</ThemedText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    padding: 8,
+  },
+});

--- a/mobile/contexts/ThemeContext.tsx
+++ b/mobile/contexts/ThemeContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Appearance } from 'react-native';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(
+    (Appearance.getColorScheme() as Theme) ?? 'light'
+  );
+
+  const toggle = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be inside ThemeProvider');
+  return ctx;
+}

--- a/mobile/hooks/useColorScheme.ts
+++ b/mobile/hooks/useColorScheme.ts
@@ -1,1 +1,6 @@
-export { useColorScheme } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+
+export function useColorScheme() {
+  const { theme } = useTheme();
+  return theme;
+}

--- a/mobile/hooks/useColorScheme.web.ts
+++ b/mobile/hooks/useColorScheme.web.ts
@@ -1,21 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
-
-  const colorScheme = useRNColorScheme();
-
-  if (hasHydrated) {
-    return colorScheme;
-  }
-
-  return 'light';
+  const { theme } = useTheme();
+  return theme;
 }


### PR DESCRIPTION
## Summary
- create ThemeContext with toggle functionality
- update useColorScheme to use ThemeContext
- wrap app in ThemeProvider
- add ThemeToggleButton component and show button on all tabs
- fix DateTimePicker visibility and use themed modal background
- tweak analytics chart colors for income vs expense

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68618d0292208327a049317b3cfce2b1