### PR TITLE
Add budgeting planner tab

### DIFF
--- a/mobile/app/(tabs)/planner.tsx
+++ b/mobile/app/(tabs)/planner.tsx
@@ -1,23 +1,187 @@
-import { StyleSheet } from 'react-native';
+import React from 'react';
+import { StyleSheet, View, TextInput, ScrollView, Button } from 'react-native';
 import ThemeToggleButton from '@/components/ThemeToggleButton';
 import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
+import { useBudget } from '@/contexts/BudgetContext';
+import { usePlanning } from '@/contexts/PlanningContext';
 
 export default function PlannerScreen() {
+  const { transactions, categories } = useBudget();
+  const {
+    accounts,
+    debt,
+    overspend,
+    categories: planCats,
+    setAccount,
+    setDebt,
+    setOverspend,
+    setPercent,
+    setPredicted,
+    autofill,
+  } = usePlanning();
+
+  const expenseCategories = categories.filter((c) => c.type === 'expense');
+
+  const data = expenseCategories.map((c) => {
+    const plan = planCats.find((p) => p.id === c.id) || { percent: 0, predicted: 0 };
+    const current = transactions
+      .filter((t) => t.categoryId === c.id && t.type === 'expense')
+      .reduce((s, t) => s + t.amount, 0);
+    const week = plan.predicted / 4;
+    const progress = plan.predicted > 0 ? current / plan.predicted : 0;
+    return { ...c, ...plan, current, week, progress };
+  });
+
+  const totalBudget = data.reduce((s, d) => s + d.predicted, 0);
+  const totalSpent = data.reduce((s, d) => s + d.current, 0);
+  const remaining = totalBudget - totalSpent;
+
+  const balance =
+    (parseFloat(accounts.privat) || 0) +
+    (parseFloat(accounts.mono) || 0) +
+    (parseFloat(accounts.cash) || 0) +
+    (parseFloat(accounts.currency) || 0);
+
+  const predictedEnd = balance - (parseFloat(debt) || 0) - totalSpent + totalBudget;
+
   return (
-    <ThemedView style={styles.container}>
+    <ScrollView style={styles.scroll} contentContainerStyle={{ padding: 16 }}>
       <ThemeToggleButton />
-      <ThemedText type="title">Plan</ThemedText>
-      <ThemedText>Create budgets for day, month or custom periods.</ThemedText>
-    </ThemedView>
+      <ThemedText type="title">Планування</ThemedText>
+
+      <ThemedText type="subtitle">Початкове положення</ThemedText>
+      <View style={styles.row}>
+        <ThemedText>Приват</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={accounts.privat}
+          onChangeText={(v) => setAccount('privat', v)}
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText>Моно</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={accounts.mono}
+          onChangeText={(v) => setAccount('mono', v)}
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText>Готівка</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={accounts.cash}
+          onChangeText={(v) => setAccount('cash', v)}
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText>Валюта</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={accounts.currency}
+          onChangeText={(v) => setAccount('currency', v)}
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText>Борг</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={debt}
+          onChangeText={setDebt}
+        />
+      </View>
+      <View style={styles.row}>
+        <ThemedText>Перевитрати минулого місяця</ThemedText>
+        <TextInput
+          style={styles.input}
+          keyboardType="numeric"
+          value={overspend}
+          onChangeText={setOverspend}
+        />
+      </View>
+      <Button title="Автозаповнення" onPress={autofill} />
+
+      <ThemedText type="subtitle" style={{ marginTop: 16 }}>
+        Категорії
+      </ThemedText>
+      {data.map((d) => (
+        <View key={d.id} style={styles.tableRow}>
+          <ThemedText style={{ flex: 1 }}>{d.name}</ThemedText>
+          <TextInput
+            style={[styles.input, { width: 70 }]}
+            keyboardType="numeric"
+            value={String(d.predicted)}
+            onChangeText={(v) => setPredicted(d.id, parseFloat(v) || 0)}
+          />
+          <TextInput
+            style={[styles.input, { width: 60 }]}
+            keyboardType="numeric"
+            value={String(d.percent)}
+            onChangeText={(v) => setPercent(d.id, parseFloat(v) || 0)}
+          />
+          <ThemedText style={{ width: 70 }}>{d.current}</ThemedText>
+          <ThemedText style={{ width: 60 }}>{d.week.toFixed(0)}</ThemedText>
+          <View style={styles.progressBar}>
+            <View
+              style={[
+                styles.progress,
+                {
+                  width: `${Math.min(d.progress * 100, 100)}%`,
+                  backgroundColor:
+                    d.progress > 1 ? 'red' : d.progress > 0.9 ? 'yellow' : 'green',
+                },
+              ]}
+            />
+          </View>
+        </View>
+      ))}
+
+      <ThemedText type="subtitle" style={{ marginTop: 16 }}>
+        Підсумки
+      </ThemedText>
+      <ThemedText>Загальний бюджет: {totalBudget.toFixed(2)}</ThemedText>
+      <ThemedText>Витрачено: {totalSpent.toFixed(2)}</ThemedText>
+      <ThemedText>Залишок: {remaining.toFixed(2)}</ThemedText>
+      <ThemedText>
+        Прогнозований залишок на кінець місяця: {predictedEnd.toFixed(2)}
+      </ThemedText>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  scroll: { flex: 1 },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
+    paddingVertical: 4,
   },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 4,
+    borderRadius: 4,
+    minWidth: 80,
+    textAlign: 'right',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    gap: 4,
+  },
+  progressBar: {
+    flex: 1,
+    height: 8,
+    backgroundColor: '#eee',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  progress: { height: '100%' },
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { BudgetProvider } from '@/contexts/BudgetContext';
+import { PlanningProvider } from '@/contexts/PlanningContext';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 
 export default function RootLayout() {
@@ -20,15 +21,17 @@ function RootLayoutInner() {
 
   return (
     <BudgetProvider>
-      <NavigationThemeProvider
-        value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
-      >
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </NavigationThemeProvider>
+      <PlanningProvider>
+        <NavigationThemeProvider
+          value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+        >
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </NavigationThemeProvider>
+      </PlanningProvider>
     </BudgetProvider>
   );
 }

--- a/mobile/contexts/PlanningContext.tsx
+++ b/mobile/contexts/PlanningContext.tsx
@@ -1,0 +1,147 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useBudget } from './BudgetContext';
+
+export type AccountBalances = {
+  privat: string;
+  mono: string;
+  cash: string;
+  currency: string;
+};
+
+export type PlanCategory = {
+  id: string;
+  percent: number;
+  predicted: number;
+};
+
+export type PlanState = {
+  accounts: AccountBalances;
+  debt: string;
+  overspend: string;
+  categories: PlanCategory[];
+};
+
+interface PlanningContextValue extends PlanState {
+  setAccount: (name: keyof AccountBalances, value: string) => void;
+  setDebt: (value: string) => void;
+  setOverspend: (value: string) => void;
+  setPercent: (id: string, percent: number) => void;
+  setPredicted: (id: string, value: number) => void;
+  autofill: () => void;
+}
+
+const PlanningContext = createContext<PlanningContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'planning-data';
+
+export function PlanningProvider({ children }: { children: React.ReactNode }) {
+  const { categories: budgetCategories, transactions } = useBudget();
+  const expenseCategories = budgetCategories.filter((c) => c.type === 'expense');
+
+  const [state, setState] = useState<PlanState>({
+    accounts: { privat: '', mono: '', cash: '', currency: '' },
+    debt: '',
+    overspend: '',
+    categories: expenseCategories.map((c) => ({ id: c.id, percent: 0, predicted: 0 })),
+  });
+
+  useEffect(() => {
+    (async () => {
+      const json = await AsyncStorage.getItem(STORAGE_KEY);
+      if (json) {
+        try {
+          const data = JSON.parse(json) as PlanState;
+          setState({
+            ...data,
+            categories: expenseCategories.map((c) =>
+              data.categories.find((d) => d.id === c.id) || { id: c.id, percent: 0, predicted: 0 },
+            ),
+          });
+        } catch (e) {
+          console.error('Failed to load planning data', e);
+        }
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (e) {
+        console.error('Failed to save planning data', e);
+      }
+    })();
+  }, [state]);
+
+  // Update categories when budget categories change
+  useEffect(() => {
+    setState((prev) => ({
+      ...prev,
+      categories: expenseCategories.map((c) =>
+        prev.categories.find((d) => d.id === c.id) || { id: c.id, percent: 0, predicted: 0 },
+      ),
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [budgetCategories.length]);
+
+  const setAccount = (name: keyof AccountBalances, value: string) => {
+    setState((prev) => ({ ...prev, accounts: { ...prev.accounts, [name]: value } }));
+  };
+
+  const setDebt = (value: string) => setState((prev) => ({ ...prev, debt: value }));
+  const setOverspend = (value: string) => setState((prev) => ({ ...prev, overspend: value }));
+
+  const setPercent = (id: string, percent: number) => {
+    setState((prev) => ({
+      ...prev,
+      categories: prev.categories.map((c) => (c.id === id ? { ...c, percent } : c)),
+    }));
+  };
+
+  const setPredicted = (id: string, value: number) => {
+    setState((prev) => ({
+      ...prev,
+      categories: prev.categories.map((c) => (c.id === id ? { ...c, predicted: value } : c)),
+    }));
+  };
+
+  const autofill = () => {
+    const income = transactions.filter((t) => t.type === 'income').reduce((s, t) => s + t.amount, 0);
+    const expenses = transactions.filter((t) => t.type === 'expense').reduce((s, t) => s + t.amount, 0);
+    const net = income - expenses;
+    const debt = parseFloat(state.debt) || 0;
+    const overs = parseFloat(state.overspend) || 0;
+    const available = net - debt - overs;
+    setState((prev) => ({
+      ...prev,
+      categories: prev.categories.map((c) => ({
+        ...c,
+        predicted: parseFloat(((available * c.percent) / 100).toFixed(2)),
+      })),
+    }));
+  };
+
+  return (
+    <PlanningContext.Provider
+      value={{
+        ...state,
+        setAccount,
+        setDebt,
+        setOverspend,
+        setPercent,
+        setPredicted,
+        autofill,
+      }}
+    >
+      {children}
+    </PlanningContext.Provider>
+  );
+}
+
+export function usePlanning() {
+  const ctx = useContext(PlanningContext);
+  if (!ctx) throw new Error('usePlanning must be inside PlanningProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add `PlanningContext` for storing per-month budget plan data
- integrate `PlanningProvider` in app root layout
- implement new planner tab with budget table, autofill, and progress bar

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_e_6861901f57c483278300c0215b6d2d29